### PR TITLE
Fix typo in "severs" to "servers"

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -7,7 +7,7 @@ Win11React is designed to look like the Real Windows 11. Built from scratch usin
 [Main Repository](https://github.com/blueedgetechno/win11React) - Source code for the project.  
 [Store Repository](https://github.com/win11react/store) - Contains the app stores, data endpoints for apps.  
 [Docs Repository](https://github.com/win11react/docs) - Hosts this site.  
-[Status Repository](https://github.com/win11react/status) - Status of our severs and sites.
+[Status Repository](https://github.com/win11react/status) - Status of our servers and sites.
 
 ## People
 


### PR DESCRIPTION
The same typo (severs) is found in the repository description for [win11React/status](https://github.com/win11react/status) (Status of our severs and sites).

![image](https://user-images.githubusercontent.com/64314452/169651603-c459930b-ffa5-41ab-b752-c96e28e96149.png)